### PR TITLE
Add some additional tests

### DIFF
--- a/tests/test_pvacbind.py
+++ b/tests/test_pvacbind.py
@@ -60,7 +60,7 @@ def generate_class_ii_call(method, allele, path, input_path):
         input_path,
         "MHC_Class_II",
         "tmp",
-        "Test.15.fa.split_1-48"
+        "sample.name.15.fa.split_1-48"
     ), mode='r')
     text = reader.read()
     reader.close()
@@ -150,7 +150,7 @@ class PvacbindTests(unittest.TestCase):
 
             run.main([
                 os.path.join(self.test_data_directory, "input.fasta"),
-                'Test',
+                'sample.name',
                 'HLA-G*01:09,HLA-E*01:01',
                 'NetMHC',
                 'PickPocket',
@@ -164,7 +164,7 @@ class PvacbindTests(unittest.TestCase):
 
             run.main([
                 os.path.join(self.test_data_directory, "input.fasta"),
-                'Test',
+                'sample.name',
                 'H2-IAb',
                 'NNalign',
                 output_dir.name,
@@ -173,32 +173,32 @@ class PvacbindTests(unittest.TestCase):
             ])
 
             for file_name in (
-                'Test.all_epitopes.tsv',
-                'Test.filtered.tsv',
+                'sample.name.all_epitopes.tsv',
+                'sample.name.filtered.tsv',
             ):
                 output_file   = os.path.join(output_dir.name, 'MHC_Class_I', file_name)
-                expected_file = os.path.join(self.test_data_directory, 'MHC_Class_I', file_name)
-                self.assertTrue(compare(output_file, expected_file))
+                expected_file = os.path.join(self.test_data_directory, 'MHC_Class_I', file_name.replace('sample.name', 'Test'))
+                self.assertTrue(compare(output_file, expected_file), "files don't match %s - %s" %(output_file, expected_file))
 
             for file_name in (
-                'Test.9.fa.split_1-48',
-                'Test.9.fa.split_1-48.key',
-                'Test.10.fa.split_1-48',
-                'Test.10.fa.split_1-48.key',
+                'sample.name.9.fa.split_1-48',
+                'sample.name.9.fa.split_1-48.key',
+                'sample.name.10.fa.split_1-48',
+                'sample.name.10.fa.split_1-48.key',
             ):
                 output_file   = os.path.join(output_dir.name, 'MHC_Class_I', 'tmp', file_name)
-                expected_file = os.path.join(self.test_data_directory, 'MHC_Class_I', 'tmp', file_name)
-                self.assertTrue(cmp(output_file, expected_file))
+                expected_file = os.path.join(self.test_data_directory, 'MHC_Class_I', 'tmp', file_name.replace('sample.name', 'Test'))
+                self.assertTrue(cmp(output_file, expected_file), "files don't match %s - %s" %(output_file, expected_file))
 
             for file_name in (
-                'Test.HLA-G*01:09.9.parsed.tsv_1-48',
-                'Test.HLA-G*01:09.10.parsed.tsv_1-48',
-                'Test.HLA-E*01:01.9.parsed.tsv_1-48',
-                'Test.HLA-E*01:01.10.parsed.tsv_1-48',
+                'sample.name.HLA-G*01:09.9.parsed.tsv_1-48',
+                'sample.name.HLA-G*01:09.10.parsed.tsv_1-48',
+                'sample.name.HLA-E*01:01.9.parsed.tsv_1-48',
+                'sample.name.HLA-E*01:01.10.parsed.tsv_1-48',
             ):
                 output_file   = os.path.join(output_dir.name, 'MHC_Class_I', 'tmp', file_name)
-                expected_file = os.path.join(self.test_data_directory, 'MHC_Class_I', 'tmp', file_name)
-                self.assertTrue(compare(output_file, expected_file))
+                expected_file = os.path.join(self.test_data_directory, 'MHC_Class_I', 'tmp', file_name.replace('sample.name', 'Test'))
+                self.assertTrue(compare(output_file, expected_file), "files don't match %s - %s" %(output_file, expected_file))
 
             for file_name in (
                 'inputs.yml',
@@ -212,36 +212,36 @@ class PvacbindTests(unittest.TestCase):
                 for allele in methods[method].keys():
                     for length in methods[method][allele]:
                         mock_request.assert_has_calls([
-                            generate_class_i_call(method, allele, length, os.path.join(output_dir.name, "MHC_Class_I", "tmp", "Test.{}.fa.split_1-48".format(length)))
+                            generate_class_i_call(method, allele, length, os.path.join(output_dir.name, "MHC_Class_I", "tmp", "sample.name.{}.fa.split_1-48".format(length)))
                         ])
-                        output_file   = os.path.join(output_dir.name, "MHC_Class_I", "tmp", 'Test.%s.%s.%s.tsv_1-48' % (method, allele, length))
+                        output_file   = os.path.join(output_dir.name, "MHC_Class_I", "tmp", 'sample.name.%s.%s.%s.tsv_1-48' % (method, allele, length))
                         expected_file = os.path.join(self.test_data_directory, "MHC_Class_I", "tmp", 'Test.%s.%s.%s.tsv_1-48' % (method, allele, length))
-                        self.assertTrue(cmp(output_file, expected_file, False))
+                        self.assertTrue(cmp(output_file, expected_file, False), "files don't match %s - %s" %(output_file, expected_file))
 
             #Class II output files
             for file_name in (
-                'Test.all_epitopes.tsv',
-                'Test.filtered.tsv',
+                'sample.name.all_epitopes.tsv',
+                'sample.name.filtered.tsv',
             ):
                 output_file   = os.path.join(output_dir.name, 'MHC_Class_II', file_name)
-                expected_file = os.path.join(self.test_data_directory, 'MHC_Class_II', file_name)
-                self.assertTrue(compare(output_file, expected_file))
+                expected_file = os.path.join(self.test_data_directory, 'MHC_Class_II', file_name.replace('sample.name', 'Test'))
+                self.assertTrue(compare(output_file, expected_file), "files don't match %s - %s" %(output_file, expected_file))
 
             for file_name in (
-                'Test.15.fa.split_1-48',
-                'Test.15.fa.split_1-48.key',
-                'Test.nn_align.H2-IAb.15.tsv_1-48',
+                'sample.name.15.fa.split_1-48',
+                'sample.name.15.fa.split_1-48.key',
+                'sample.name.nn_align.H2-IAb.15.tsv_1-48',
             ):
                 output_file   = os.path.join(output_dir.name, 'MHC_Class_II', 'tmp', file_name)
-                expected_file = os.path.join(self.test_data_directory, 'MHC_Class_II', 'tmp', file_name)
-                self.assertTrue(cmp(output_file, expected_file, False))
+                expected_file = os.path.join(self.test_data_directory, 'MHC_Class_II', 'tmp', file_name.replace('sample.name', 'Test'))
+                self.assertTrue(cmp(output_file, expected_file, False), "files don't match %s - %s" %(output_file, expected_file))
 
             for file_name in (
-                'Test.H2-IAb.15.parsed.tsv_1-48',
+                'sample.name.H2-IAb.15.parsed.tsv_1-48',
             ):
                 output_file   = os.path.join(output_dir.name, 'MHC_Class_II', 'tmp', file_name)
-                expected_file = os.path.join(self.test_data_directory, 'MHC_Class_II', 'tmp', file_name)
-                self.assertTrue(compare(output_file, expected_file))
+                expected_file = os.path.join(self.test_data_directory, 'MHC_Class_II', 'tmp', file_name.replace('sample.name', 'Test'))
+                self.assertTrue(compare(output_file, expected_file), "files don't match %s - %s" %(output_file, expected_file))
 
             for file_name in (
                 'inputs.yml',
@@ -256,7 +256,7 @@ class PvacbindTests(unittest.TestCase):
             with self.assertRaises(SystemExit) as cm:
                 run.main([
                     os.path.join(self.test_data_directory, "input.vcf"),
-                    'Test',
+                    'sample.name',
                     'H2-IAb',
                     'NNalign',
                     output_dir.name,

--- a/tests/test_pvacfuse.py
+++ b/tests/test_pvacfuse.py
@@ -59,7 +59,7 @@ def generate_class_ii_call(method, allele, path, input_path):
         input_path,
         "MHC_Class_II",
         "tmp",
-        "Test_31.fa.split_1-48"
+        "sample.name_31.fa.split_1-48"
     ), mode='r')
     text = reader.read()
     reader.close()
@@ -138,7 +138,7 @@ class PvacfuseTests(unittest.TestCase):
 
             run.main([
                 os.path.join(self.test_data_directory, "fusions_annotated.bedpe"),
-                'Test',
+                'sample.name',
                 'HLA-A*29:02',
                 'NetMHC',
                 output_dir.name,
@@ -148,28 +148,28 @@ class PvacfuseTests(unittest.TestCase):
             ])
 
             for file_name in (
-                'Test.tsv',
-                'Test.tsv_1-4',
-                'Test.all_epitopes.tsv',
-                'Test.filtered.tsv',
-                'Test.filtered.condensed.ranked.tsv',
+                'sample.name.tsv',
+                'sample.name.tsv_1-4',
+                'sample.name.all_epitopes.tsv',
+                'sample.name.filtered.tsv',
+                'sample.name.filtered.condensed.ranked.tsv',
             ):
                 output_file   = os.path.join(output_dir.name, 'MHC_Class_I', file_name)
-                expected_file = os.path.join(self.test_data_directory, 'fusions', 'MHC_Class_I', file_name)
-                self.assertTrue(compare(output_file, expected_file))
+                expected_file = os.path.join(self.test_data_directory, 'fusions', 'MHC_Class_I', file_name.replace('sample.name', 'Test'))
+                self.assertTrue(compare(output_file, expected_file),  "files don't match %s - %s" %(output_file, expected_file))
 
             for file_name in (
-                'Test_21.fa.split_1-8',
-                'Test_21.fa.split_1-8.key',
-                'Test.ann.HLA-A*29:02.9.tsv_1-8',
-                'Test.HLA-A*29:02.9.parsed.tsv_1-8',
+                'sample.name_21.fa.split_1-8',
+                'sample.name_21.fa.split_1-8.key',
+                'sample.name.ann.HLA-A*29:02.9.tsv_1-8',
+                'sample.name.HLA-A*29:02.9.parsed.tsv_1-8',
             ):
                 output_file   = os.path.join(output_dir.name, 'MHC_Class_I', 'tmp', file_name)
-                expected_file = os.path.join(self.test_data_directory, 'fusions', 'MHC_Class_I', 'tmp', file_name)
-                self.assertTrue(compare(output_file, expected_file))
+                expected_file = os.path.join(self.test_data_directory, 'fusions', 'MHC_Class_I', 'tmp', file_name.replace('sample.name', 'Test'))
+                self.assertTrue(compare(output_file, expected_file), "files don't match %s - %s" %(output_file, expected_file))
 
             mock_request.assert_has_calls([
-                generate_class_i_call('ann', 'HLA-A*29:02', 9, os.path.join(output_dir.name, "MHC_Class_I", "tmp", "Test_21.fa.split_1-8"))
+                generate_class_i_call('ann', 'HLA-A*29:02', 9, os.path.join(output_dir.name, "MHC_Class_I", "tmp", "sample.name_21.fa.split_1-8"))
             ])
 
             output_dir.cleanup()

--- a/tests/test_pvacseq.py
+++ b/tests/test_pvacseq.py
@@ -182,7 +182,7 @@ class PvacseqTests(unittest.TestCase):
             ):
                 output_file   = os.path.join(output_dir.name, 'MHC_Class_I', file_name)
                 expected_file = os.path.join(self.test_data_directory, 'MHC_Class_I', file_name.replace('sample.name', 'Test'))
-                self.assertTrue(compare(output_file, expected_file))
+                self.assertTrue(compare(output_file, expected_file), "files don't match %s - %s" %(output_file, expected_file))
 
             for file_name in (
                 'sample.name.tsv',
@@ -210,7 +210,7 @@ class PvacseqTests(unittest.TestCase):
             ):
                 output_file   = os.path.join(output_dir.name, 'MHC_Class_I', 'tmp', file_name)
                 expected_file = os.path.join(self.test_data_directory, 'MHC_Class_I', 'tmp', file_name.replace('sample.name', 'Test'))
-                self.assertTrue(compare(output_file, expected_file))
+                self.assertTrue(compare(output_file, expected_file), "files don't match %s - %s" %(output_file, expected_file))
 
             for file_name in (
                 'inputs.yml',
@@ -240,7 +240,7 @@ class PvacseqTests(unittest.TestCase):
             ):
                 output_file   = os.path.join(output_dir.name, 'MHC_Class_II', file_name)
                 expected_file = os.path.join(self.test_data_directory, 'MHC_Class_II', file_name.replace('sample.name', 'Test'))
-                self.assertTrue(compare(output_file, expected_file))
+                self.assertTrue(compare(output_file, expected_file), "files don't match %s - %s" %(output_file, expected_file))
 
             for file_name in (
                 'sample.name_31.fa.split_1-48',
@@ -256,7 +256,7 @@ class PvacseqTests(unittest.TestCase):
             ):
                 output_file   = os.path.join(output_dir.name, 'MHC_Class_II', 'tmp', file_name)
                 expected_file = os.path.join(self.test_data_directory, 'MHC_Class_II', 'tmp', file_name.replace('sample.name', 'Test'))
-                self.assertTrue(compare(output_file, expected_file))
+                self.assertTrue(compare(output_file, expected_file), "files don't match %s - %s" %(output_file, expected_file))
 
             for file_name in (
                 'inputs.yml',


### PR DESCRIPTION
PR https://github.com/griffithlab/pVACtools/pull/505 adds some tests for sample names with dots to pVACseq, but not to pVACbind and pVACfuse. This PR will add tests for those modules as well.

This PR also adds more verbose assert messages to any `compare` test in the pVACseq test.